### PR TITLE
Enable rules-based character creation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from typing import List, Dict
 import io
+import json
+import os
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 
@@ -21,13 +23,14 @@ app.add_middleware(
 ABILITIES = ["Observation", "Exploration", "Deduction", "Traversal"]
 LICENSES = ["Archivist", "Diviner", "Fixer", "Guardian"]
 
-# Placeholder skill and interaction data
-SKILLS: Dict[str, List[str]] = {
-    "Archivist": ["Local Knowledge", "Cartographer's Tools", "Biologist"],
-    "Diviner": ["Whispers", "Cartomancer", "Ossiomancer"],
-    "Fixer": ["Tinker", "Mechanic", "Smuggler"],
-    "Guardian": ["Protector", "Warrior", "Bodyguard"],
-}
+# Load skills from skills.json
+SKILL_FILE = os.path.join(os.path.dirname(__file__), "..", "skills.json")
+with open(SKILL_FILE, "r", encoding="utf-8") as f:
+    skill_rows = json.load(f)
+
+SKILLS: Dict[str, List[str]] = {}
+for row in skill_rows:
+    SKILLS.setdefault(row["class"], []).append(row["name"])
 
 INTERACTIONS: Dict[str, List[str]] = {
     "Archivist": ["Research", "Analyse", "Catalog"],
@@ -66,11 +69,34 @@ def get_skills(license: str):
 def get_interactions(license: str):
     return INTERACTIONS.get(license, [])
 
+
+def validate_character(char: Character):
+    dice_values = list(char.abilities.model_dump().values())
+    allowed = {"D4", "D6"}
+    if any(d not in allowed for d in dice_values):
+        raise HTTPException(status_code=400, detail="Abilities must be D4 or D6")
+    if sorted(dice_values) != ["D4", "D4", "D6", "D6"]:
+        raise HTTPException(status_code=400, detail="Abilities must use two D4 and two D6")
+
+    if char.license == "Archivist":
+        if char.abilities.Observation != "D6" or char.abilities.Traversal != "D4":
+            raise HTTPException(status_code=400, detail="Archivist must have D6 Observation and D4 Traversal")
+    elif char.license == "Fixer":
+        if char.abilities.Deduction != "D6" or char.abilities.Traversal != "D4":
+            raise HTTPException(status_code=400, detail="Fixer must have D6 Deduction and D4 Traversal")
+    elif char.license == "Guardian":
+        if char.abilities.Traversal != "D6" or char.abilities.Deduction != "D4":
+            raise HTTPException(status_code=400, detail="Guardian must have D6 Traversal and D4 Deduction")
+    elif char.license == "Diviner":
+        # No fixed abilities, just ensure distribution is correct
+        pass
+    else:
+        raise HTTPException(status_code=400, detail="Invalid license")
+
 @app.post("/characters", response_model=Character)
 def create_character(char: Character):
     global next_id
-    if char.license not in LICENSES:
-        raise HTTPException(status_code=400, detail="Invalid license")
+    validate_character(char)
     char.id = next_id
     next_id += 1
     characters[char.id] = char
@@ -113,4 +139,8 @@ def export_character(char_id: int):
     pdf.showPage()
     pdf.save()
     buffer.seek(0)
-    return StreamingResponse(buffer, media_type="application/pdf", headers={"Content-Disposition": f"attachment; filename=character_{char_id}.pdf"})
+    return StreamingResponse(
+        buffer,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f"inline; filename=character_{char_id}.pdf"},
+    )

--- a/frontend/src/app/character-form.component.html
+++ b/frontend/src/app/character-form.component.html
@@ -17,8 +17,16 @@
 
   <div>
     <h3>Abilities</h3>
+    <div *ngIf="model.license === 'Diviner'">
+      <button (click)="rollDiviner()">Roll Strength/Weakness</button>
+    </div>
     <div *ngFor="let key of abilityKeys">
-      <label>{{key}}: <input [(ngModel)]="model.abilities[key]" /></label>
+      <label>{{key}}:
+        <select [(ngModel)]="model.abilities[key]">
+          <option value="">--</option>
+          <option *ngFor="let d of diceOptions" [value]="d">{{d}}</option>
+        </select>
+      </label>
     </div>
   </div>
 
@@ -37,4 +45,7 @@
   </div>
 
   <button class="save" (click)="save()">Save</button>
+  <div *ngIf="lastId">
+    <a [href]="exportUrl()" target="_blank">Download Sheet</a>
+  </div>
 </div>

--- a/frontend/src/app/character-form.component.ts
+++ b/frontend/src/app/character-form.component.ts
@@ -21,6 +21,7 @@ export class CharacterFormComponent implements OnInit {
   skills: string[] = [];
   interactions: string[] = [];
   abilityKeys = ['Observation', 'Exploration', 'Deduction', 'Traversal'];
+  diceOptions = ['D4', 'D6'];
   model: Character = {
     name: '',
     description: '',
@@ -35,6 +36,8 @@ export class CharacterFormComponent implements OnInit {
     interactions: []
   };
 
+  lastId: number | null = null;
+
   constructor(private api: ApiService) {}
 
   ngOnInit() {
@@ -45,6 +48,37 @@ export class CharacterFormComponent implements OnInit {
     if (!this.model.license) return;
     this.api.getSkills(this.model.license).subscribe(s => this.skills = s);
     this.api.getInteractions(this.model.license).subscribe(i => this.interactions = i);
+
+    // preset strength and weakness according to the chosen license
+    const reset = () => this.abilityKeys.forEach(k => this.model.abilities[k] = '');
+    reset();
+    switch (this.model.license) {
+      case 'Archivist':
+        this.model.abilities['Observation'] = 'D6';
+        this.model.abilities['Traversal'] = 'D4';
+        break;
+      case 'Fixer':
+        this.model.abilities['Deduction'] = 'D6';
+        this.model.abilities['Traversal'] = 'D4';
+        break;
+      case 'Guardian':
+        this.model.abilities['Traversal'] = 'D6';
+        this.model.abilities['Deduction'] = 'D4';
+        break;
+      case 'Diviner':
+        // strength/weakness will be rolled
+        break;
+    }
+  }
+
+  rollDiviner() {
+    if (this.model.license !== 'Diviner') return;
+    const abilities = [...this.abilityKeys];
+    const strength = abilities.splice(Math.floor(Math.random() * abilities.length), 1)[0];
+    const weakness = abilities[Math.floor(Math.random() * abilities.length)];
+    this.abilityKeys.forEach(k => this.model.abilities[k] = '');
+    this.model.abilities[strength] = 'D6';
+    this.model.abilities[weakness] = 'D4';
   }
 
   toggleSkill(skill: string, checked: boolean) {
@@ -64,8 +98,17 @@ export class CharacterFormComponent implements OnInit {
   }
 
   save() {
-    this.api.createCharacter(this.model).subscribe(res => {
-      alert('Character saved with id ' + res.id);
+    this.api.createCharacter(this.model).subscribe({
+      next: res => {
+        this.lastId = res.id;
+        alert('Character saved with id ' + res.id);
+        window.location.href = this.exportUrl();
+      },
+      error: err => alert(err.error.detail || 'Error saving character')
     });
+  }
+
+  exportUrl(): string {
+    return `http://localhost:8000/characters/${this.lastId}/export`;
   }
 }


### PR DESCRIPTION
## Summary
- read available skills from `skills.json`
- enforce ability rules for each licence when creating characters
- show dropdowns for ability dice and preset strengths/weaknesses
- add a "roll" button to generate Diviner strength/weakness randomly
- enable PDF download link after saving
- redirect to generated PDF sheet upon save

## Testing
- `python -m py_compile backend/app/main.py`
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866267528348322b5e1306524bbd068