### PR TITLE
Add validation and display created character

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,17 +23,42 @@ LICENSES = ["Archivist", "Diviner", "Fixer", "Guardian"]
 
 # Placeholder skill and interaction data
 SKILLS: Dict[str, List[str]] = {
-    "Archivist": ["Local Knowledge", "Cartographer's Tools", "Biologist"],
-    "Diviner": ["Whispers", "Cartomancer", "Ossiomancer"],
-    "Fixer": ["Tinker", "Mechanic", "Smuggler"],
-    "Guardian": ["Protector", "Warrior", "Bodyguard"],
+    # Using a subset of the official skill list for brevity
+    "Archivist": [
+        "Local Knowledge",
+        "Geography",
+        "Twitcher",
+        "Wanderer",
+        "Behaviourist",
+    ],
+    "Diviner": [
+        "Whispers",
+        "Intentions",
+        "Patterns",
+        "Presence",
+        "Memories",
+    ],
+    "Fixer": [
+        "Relationships",
+        "Resourceful",
+        "People Watcher",
+        "Steady Hands",
+        "Inner Workings",
+    ],
+    "Guardian": [
+        "Wide Ranging",
+        "Awareness",
+        "Sixth Sense",
+        "Quick Thinking",
+        "Keen Eyed",
+    ],
 }
 
 INTERACTIONS: Dict[str, List[str]] = {
-    "Archivist": ["Research", "Analyse", "Catalog"],
-    "Diviner": ["Predict", "Read Bones", "Interpret"],
-    "Fixer": ["Negotiate", "Repair", "Trade"],
-    "Guardian": ["Defend", "Intimidate", "Lead"],
+    "Archivist": ["Diagnose", "Sketch", "Study", "Take Samples", "Talk"],
+    "Diviner": ["Gift", "Read", "Sing", "Soothe", "Touch"],
+    "Fixer": ["Bait", "Gift", "Provoke", "Read", "Touch"],
+    "Guardian": ["Explore", "Feed", "Play", "Protect", "Provoke"],
 }
 
 class AbilityDice(BaseModel):
@@ -71,6 +96,45 @@ def create_character(char: Character):
     global next_id
     if char.license not in LICENSES:
         raise HTTPException(status_code=400, detail="Invalid license")
+
+    # validate ability dice: only D4 or D6, two of each
+    dice = {k: v.strip().lower() for k, v in char.abilities.model_dump().items()}
+    counts = {"d4": 0, "d6": 0}
+    for die in dice.values():
+        if die not in counts:
+            raise HTTPException(status_code=400, detail="Abilities must use D4 or D6")
+        counts[die] += 1
+    if counts["d4"] != 2 or counts["d6"] != 2:
+        raise HTTPException(status_code=400, detail="Assign exactly two D4 and two D6 to abilities")
+
+    # enforce strength and weakness for most licences
+    training = {
+        "Archivist": {"strength": "Observation", "weakness": "Traversal"},
+        "Fixer": {"strength": "Deduction", "weakness": "Traversal"},
+        "Guardian": {"strength": "Traversal", "weakness": "Deduction"},
+    }
+    rules = training.get(char.license)
+    if rules:
+        if dice[rules["strength"]] != "d6" or dice[rules["weakness"]] != "d4":
+            raise HTTPException(
+                status_code=400,
+                detail=f"{char.license} requires {rules['strength']} d6 and {rules['weakness']} d4",
+            )
+
+    # validate selected skills
+    allowed_skills = SKILLS.get(char.license, [])
+    if any(s not in allowed_skills for s in char.skills):
+        raise HTTPException(status_code=400, detail="Invalid skill for licence")
+    if len(char.skills) != 4:
+        raise HTTPException(status_code=400, detail="Choose exactly four starting skills")
+
+    # validate interactions
+    allowed_interactions = INTERACTIONS.get(char.license, [])
+    if any(i not in allowed_interactions for i in char.interactions):
+        raise HTTPException(status_code=400, detail="Invalid interaction for licence")
+    if len(char.interactions) != 3:
+        raise HTTPException(status_code=400, detail="Choose exactly three interactions")
+
     char.id = next_id
     next_id += 1
     characters[char.id] = char

--- a/frontend/src/app/character-form.component.html
+++ b/frontend/src/app/character-form.component.html
@@ -38,3 +38,19 @@
 
   <button class="save" (click)="save()">Save</button>
 </div>
+
+<div *ngIf="created" class="result-card">
+  <h2>Saved Character</h2>
+  <p><strong>ID:</strong> {{created?.id}}</p>
+  <p><strong>Name:</strong> {{created?.name}}</p>
+  <p><strong>Description:</strong> {{created?.description}}</p>
+  <p><strong>License:</strong> {{created?.license}}</p>
+  <div>
+    <h3>Abilities</h3>
+    <div *ngFor="let key of abilityKeys">
+      {{key}}: {{created?.abilities[key]}}
+    </div>
+  </div>
+  <p><strong>Skills:</strong> {{created?.skills.join(', ')}}</p>
+  <p><strong>Interactions:</strong> {{created?.interactions.join(', ')}}</p>
+</div>

--- a/frontend/src/app/character-form.component.ts
+++ b/frontend/src/app/character-form.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ApiService } from './api.service';
 
 interface Character {
+  id?: number;
   name: string;
   description: string;
   license: string;
@@ -34,6 +35,7 @@ export class CharacterFormComponent implements OnInit {
     skills: [],
     interactions: []
   };
+  created: Character | null = null;
 
   constructor(private api: ApiService) {}
 
@@ -64,8 +66,13 @@ export class CharacterFormComponent implements OnInit {
   }
 
   save() {
-    this.api.createCharacter(this.model).subscribe(res => {
-      alert('Character saved with id ' + res.id);
+    this.api.createCharacter(this.model).subscribe({
+      next: res => {
+        this.created = res as Character;
+      },
+      error: err => {
+        alert('Error: ' + (err.error?.detail || 'unknown'));
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- load sample skills and interactions from PDF data
- validate skills count exactly four
- show created character details in the frontend

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68662dbcc66c8322946f18cbad7e9180