### PR TITLE
Add validation and display created character

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,17 +23,42 @@ LICENSES = ["Archivist", "Diviner", "Fixer", "Guardian"]
 
 # Placeholder skill and interaction data
 SKILLS: Dict[str, List[str]] = {
-    "Archivist": ["Local Knowledge", "Cartographer's Tools", "Biologist"],
-    "Diviner": ["Whispers", "Cartomancer", "Ossiomancer"],
-    "Fixer": ["Tinker", "Mechanic", "Smuggler"],
-    "Guardian": ["Protector", "Warrior", "Bodyguard"],
+    # Using a subset of the official skill list for brevity
+    "Archivist": [
+        "Local Knowledge",
+        "Geography",
+        "Twitcher",
+        "Wanderer",
+        "Behaviourist",
+    ],
+    "Diviner": [
+        "Whispers",
+        "Intentions",
+        "Patterns",
+        "Presence",
+        "Memories",
+    ],
+    "Fixer": [
+        "Relationships",
+        "Resourceful",
+        "People Watcher",
+        "Steady Hands",
+        "Inner Workings",
+    ],
+    "Guardian": [
+        "Wide Ranging",
+        "Awareness",
+        "Sixth Sense",
+        "Quick Thinking",
+        "Keen Eyed",
+    ],
 }
 
 INTERACTIONS: Dict[str, List[str]] = {
-    "Archivist": ["Research", "Analyse", "Catalog"],
-    "Diviner": ["Predict", "Read Bones", "Interpret"],
-    "Fixer": ["Negotiate", "Repair", "Trade"],
-    "Guardian": ["Defend", "Intimidate", "Lead"],
+    "Archivist": ["Diagnose", "Sketch", "Study", "Take Samples", "Talk"],
+    "Diviner": ["Gift", "Read", "Sing", "Soothe", "Touch"],
+    "Fixer": ["Bait", "Gift", "Provoke", "Read", "Touch"],
+    "Guardian": ["Explore", "Feed", "Play", "Protect", "Provoke"],
 }
 
 class AbilityDice(BaseModel):
@@ -71,6 +96,45 @@ def create_character(char: Character):
     global next_id
     if char.license not in LICENSES:
         raise HTTPException(status_code=400, detail="Invalid license")
+
+    # validate ability dice: only D4 or D6, two of each
+    dice = {k: v.strip().lower() for k, v in char.abilities.model_dump().items()}
+    counts = {"d4": 0, "d6": 0}
+    for die in dice.values():
+        if die not in counts:
+            raise HTTPException(status_code=400, detail="Abilities must use D4 or D6")
+        counts[die] += 1
+    if counts["d4"] != 2 or counts["d6"] != 2:
+        raise HTTPException(status_code=400, detail="Assign exactly two D4 and two D6 to abilities")
+
+    # enforce strength and weakness for most licences
+    training = {
+        "Archivist": {"strength": "Observation", "weakness": "Traversal"},
+        "Fixer": {"strength": "Deduction", "weakness": "Traversal"},
+        "Guardian": {"strength": "Traversal", "weakness": "Deduction"},
+    }
+    rules = training.get(char.license)
+    if rules:
+        if dice[rules["strength"]] != "d6" or dice[rules["weakness"]] != "d4":
+            raise HTTPException(
+                status_code=400,
+                detail=f"{char.license} requires {rules['strength']} d6 and {rules['weakness']} d4",
+            )
+
+    # validate selected skills
+    allowed_skills = SKILLS.get(char.license, [])
+    if any(s not in allowed_skills for s in char.skills):
+        raise HTTPException(status_code=400, detail="Invalid skill for licence")
+    if len(char.skills) != 4:
+        raise HTTPException(status_code=400, detail="Choose exactly four starting skills")
+
+    # validate interactions
+    allowed_interactions = INTERACTIONS.get(char.license, [])
+    if any(i not in allowed_interactions for i in char.interactions):
+        raise HTTPException(status_code=400, detail="Invalid interaction for licence")
+    if len(char.interactions) != 3:
+        raise HTTPException(status_code=400, detail="Choose exactly three interactions")
+
     char.id = next_id
     next_id += 1
     characters[char.id] = char

--- a/frontend/src/app/character-form.component.html
+++ b/frontend/src/app/character-form.component.html
@@ -18,8 +18,20 @@
   <div>
     <h3>Abilities</h3>
     <div *ngFor="let key of abilityKeys">
-      <label>{{key}}: <input [(ngModel)]="model.abilities[key]" /></label>
+      <label>
+        {{key}}:
+        <select [(ngModel)]="model.abilities[key]" [disabled]="locked.has(key)">
+          <option value="d4">D4</option>
+          <option value="d6">D6</option>
+        </select>
+        <span *ngIf="locked.has(key)">
+          {{ model.abilities[key] === 'd6' ? '(Strength)' : '(Weakness)' }}
+        </span>
+      </label>
     </div>
+    <button *ngIf="model.license === 'Diviner'" (click)="randomizeDiviner()">
+      Roll Strength & Weakness
+    </button>
   </div>
 
   <div>
@@ -37,4 +49,20 @@
   </div>
 
   <button class="save" (click)="save()">Save</button>
+</div>
+
+<div *ngIf="created" class="result-card">
+  <h2>Saved Character</h2>
+  <p><strong>ID:</strong> {{created?.id}}</p>
+  <p><strong>Name:</strong> {{created?.name}}</p>
+  <p><strong>Description:</strong> {{created?.description}}</p>
+  <p><strong>License:</strong> {{created?.license}}</p>
+  <div>
+    <h3>Abilities</h3>
+    <div *ngFor="let key of abilityKeys">
+      {{key}}: {{created?.abilities[key]}}
+    </div>
+  </div>
+  <p><strong>Skills:</strong> {{created?.skills.join(', ')}}</p>
+  <p><strong>Interactions:</strong> {{created?.interactions.join(', ')}}</p>
 </div>

--- a/frontend/src/app/character-form.component.ts
+++ b/frontend/src/app/character-form.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ApiService } from './api.service';
 
 interface Character {
+  id?: number;
   name: string;
   description: string;
   license: string;
@@ -21,6 +22,7 @@ export class CharacterFormComponent implements OnInit {
   skills: string[] = [];
   interactions: string[] = [];
   abilityKeys = ['Observation', 'Exploration', 'Deduction', 'Traversal'];
+  locked: Set<string> = new Set();
   model: Character = {
     name: '',
     description: '',
@@ -34,6 +36,7 @@ export class CharacterFormComponent implements OnInit {
     skills: [],
     interactions: []
   };
+  created: Character | null = null;
 
   constructor(private api: ApiService) {}
 
@@ -45,6 +48,42 @@ export class CharacterFormComponent implements OnInit {
     if (!this.model.license) return;
     this.api.getSkills(this.model.license).subscribe(s => this.skills = s);
     this.api.getInteractions(this.model.license).subscribe(i => this.interactions = i);
+    this.setTrainingDefaults();
+  }
+
+  setTrainingDefaults() {
+    this.locked.clear();
+    this.abilityKeys.forEach(k => this.model.abilities[k] = '');
+    const rules: any = {
+      Archivist: {strength: 'Observation', weakness: 'Traversal'},
+      Fixer: {strength: 'Deduction', weakness: 'Traversal'},
+      Guardian: {strength: 'Traversal', weakness: 'Deduction'},
+    };
+    const r = rules[this.model.license as keyof typeof rules];
+    if (r) {
+      this.locked.add(r.strength);
+      this.locked.add(r.weakness);
+      this.model.abilities[r.strength] = 'd6';
+      this.model.abilities[r.weakness] = 'd4';
+      const rest = this.abilityKeys.filter(k => !this.locked.has(k));
+      // default remaining assignments
+      this.model.abilities[rest[0]] = 'd6';
+      this.model.abilities[rest[1]] = 'd4';
+    }
+  }
+
+  randomizeDiviner() {
+    if (this.model.license !== 'Diviner') return;
+    this.locked.clear();
+    const pool = [...this.abilityKeys];
+    const strength = pool.splice(Math.floor(Math.random() * pool.length), 1)[0];
+    const weakness = pool.splice(Math.floor(Math.random() * pool.length), 1)[0];
+    this.locked.add(strength);
+    this.locked.add(weakness);
+    this.model.abilities[strength] = 'd6';
+    this.model.abilities[weakness] = 'd4';
+    this.model.abilities[pool[0]] = 'd6';
+    this.model.abilities[pool[1]] = 'd4';
   }
 
   toggleSkill(skill: string, checked: boolean) {
@@ -64,8 +103,13 @@ export class CharacterFormComponent implements OnInit {
   }
 
   save() {
-    this.api.createCharacter(this.model).subscribe(res => {
-      alert('Character saved with id ' + res.id);
+    this.api.createCharacter(this.model).subscribe({
+      next: res => {
+        this.created = res as Character;
+      },
+      error: err => {
+        alert('Error: ' + (err.error?.detail || 'unknown'));
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary
- load sample skills and interactions from PDF data
- validate skills count exactly four
- show created character details in the frontend
- set Strength/Weakness dice for each licence
- add random Strength/Weakness button for Diviners

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68662dbcc66c8322946f18cbad7e9180