### PR TITLE
Improve ability selection and UI

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,17 +23,42 @@ LICENSES = ["Archivist", "Diviner", "Fixer", "Guardian"]
 
 # Placeholder skill and interaction data
 SKILLS: Dict[str, List[str]] = {
-    "Archivist": ["Local Knowledge", "Cartographer's Tools", "Biologist"],
-    "Diviner": ["Whispers", "Cartomancer", "Ossiomancer"],
-    "Fixer": ["Tinker", "Mechanic", "Smuggler"],
-    "Guardian": ["Protector", "Warrior", "Bodyguard"],
+    # Using a subset of the official skill list for brevity
+    "Archivist": [
+        "Local Knowledge",
+        "Geography",
+        "Twitcher",
+        "Wanderer",
+        "Behaviourist",
+    ],
+    "Diviner": [
+        "Whispers",
+        "Intentions",
+        "Patterns",
+        "Presence",
+        "Memories",
+    ],
+    "Fixer": [
+        "Relationships",
+        "Resourceful",
+        "People Watcher",
+        "Steady Hands",
+        "Inner Workings",
+    ],
+    "Guardian": [
+        "Wide Ranging",
+        "Awareness",
+        "Sixth Sense",
+        "Quick Thinking",
+        "Keen Eyed",
+    ],
 }
 
 INTERACTIONS: Dict[str, List[str]] = {
-    "Archivist": ["Research", "Analyse", "Catalog"],
-    "Diviner": ["Predict", "Read Bones", "Interpret"],
-    "Fixer": ["Negotiate", "Repair", "Trade"],
-    "Guardian": ["Defend", "Intimidate", "Lead"],
+    "Archivist": ["Diagnose", "Sketch", "Study", "Take Samples", "Talk"],
+    "Diviner": ["Gift", "Read", "Sing", "Soothe", "Touch"],
+    "Fixer": ["Bait", "Gift", "Provoke", "Read", "Touch"],
+    "Guardian": ["Explore", "Feed", "Play", "Protect", "Provoke"],
 }
 
 class AbilityDice(BaseModel):
@@ -71,6 +96,45 @@ def create_character(char: Character):
     global next_id
     if char.license not in LICENSES:
         raise HTTPException(status_code=400, detail="Invalid license")
+
+    # validate ability dice: only D4 or D6, two of each
+    dice = {k: v.strip().lower() for k, v in char.abilities.model_dump().items()}
+    counts = {"d4": 0, "d6": 0}
+    for die in dice.values():
+        if die not in counts:
+            raise HTTPException(status_code=400, detail="Abilities must use D4 or D6")
+        counts[die] += 1
+    if counts["d4"] != 2 or counts["d6"] != 2:
+        raise HTTPException(status_code=400, detail="Assign exactly two D4 and two D6 to abilities")
+
+    # enforce strength and weakness for most licences
+    training = {
+        "Archivist": {"strength": "Observation", "weakness": "Traversal"},
+        "Fixer": {"strength": "Deduction", "weakness": "Traversal"},
+        "Guardian": {"strength": "Traversal", "weakness": "Deduction"},
+    }
+    rules = training.get(char.license)
+    if rules:
+        if dice[rules["strength"]] != "d6" or dice[rules["weakness"]] != "d4":
+            raise HTTPException(
+                status_code=400,
+                detail=f"{char.license} requires {rules['strength']} d6 and {rules['weakness']} d4",
+            )
+
+    # validate selected skills
+    allowed_skills = SKILLS.get(char.license, [])
+    if any(s not in allowed_skills for s in char.skills):
+        raise HTTPException(status_code=400, detail="Invalid skill for licence")
+    if len(char.skills) != 4:
+        raise HTTPException(status_code=400, detail="Choose exactly four starting skills")
+
+    # validate interactions
+    allowed_interactions = INTERACTIONS.get(char.license, [])
+    if any(i not in allowed_interactions for i in char.interactions):
+        raise HTTPException(status_code=400, detail="Invalid interaction for licence")
+    if len(char.interactions) != 3:
+        raise HTTPException(status_code=400, detail="Choose exactly three interactions")
+
     char.id = next_id
     next_id += 1
     characters[char.id] = char

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -1,4 +1,5 @@
 h1 {
   text-align: center;
   margin: 2rem 0 1rem;
+  color: #3f51b5;
 }

--- a/frontend/src/app/character-form.component.css
+++ b/frontend/src/app/character-form.component.css
@@ -8,11 +8,12 @@ h3 {
   margin-bottom: 0.5rem;
 }
 
-.form-card {
-  background: #fff;
+.form-card,
+.result-card {
+  background: linear-gradient(#ffffff, #fafafa);
   padding: 1.5rem;
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   max-width: 600px;
   margin: 2rem auto;
 }
@@ -29,13 +30,14 @@ input[type="text"], textarea, select {
   display: block;
   margin: 2rem auto 0;
   padding: 0.5rem 1.5rem;
-  background-color: #007bff;
+  background: linear-gradient(45deg, #42a5f5, #478ed1);
   color: #fff;
   border: none;
   border-radius: 4px;
   cursor: pointer;
+  transition: background 0.3s ease;
 }
 
 .save:hover {
-  background-color: #0056b3;
+  background: linear-gradient(45deg, #478ed1, #42a5f5);
 }

--- a/frontend/src/app/character-form.component.html
+++ b/frontend/src/app/character-form.component.html
@@ -18,8 +18,24 @@
   <div>
     <h3>Abilities</h3>
     <div *ngFor="let key of abilityKeys">
-      <label>{{key}}: <input [(ngModel)]="model.abilities[key]" /></label>
+      <label>
+        {{key}}:
+        <select
+          [(ngModel)]="model.abilities[key]"
+          [disabled]="locked.has(key)"
+        >
+          <option value="">--</option>
+          <option value="d4" [disabled]="isDieDisabled(key, 'd4')">D4</option>
+          <option value="d6" [disabled]="isDieDisabled(key, 'd6')">D6</option>
+        </select>
+        <span *ngIf="locked.has(key)">
+          {{ model.abilities[key] === 'd6' ? '(Strength)' : '(Weakness)' }}
+        </span>
+      </label>
     </div>
+    <button *ngIf="model.license === 'Diviner'" (click)="randomizeDiviner()">
+      Roll Strength & Weakness
+    </button>
   </div>
 
   <div>
@@ -37,4 +53,20 @@
   </div>
 
   <button class="save" (click)="save()">Save</button>
+</div>
+
+<div *ngIf="created" class="result-card">
+  <h2>Saved Character</h2>
+  <p><strong>ID:</strong> {{created?.id}}</p>
+  <p><strong>Name:</strong> {{created?.name}}</p>
+  <p><strong>Description:</strong> {{created?.description}}</p>
+  <p><strong>License:</strong> {{created?.license}}</p>
+  <div>
+    <h3>Abilities</h3>
+    <div *ngFor="let key of abilityKeys">
+      {{key}}: {{created?.abilities[key]}}
+    </div>
+  </div>
+  <p><strong>Skills:</strong> {{created?.skills.join(', ')}}</p>
+  <p><strong>Interactions:</strong> {{created?.interactions.join(', ')}}</p>
 </div>

--- a/frontend/src/app/character-form.component.ts
+++ b/frontend/src/app/character-form.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ApiService } from './api.service';
 
 interface Character {
+  id?: number;
   name: string;
   description: string;
   license: string;
@@ -21,6 +22,7 @@ export class CharacterFormComponent implements OnInit {
   skills: string[] = [];
   interactions: string[] = [];
   abilityKeys = ['Observation', 'Exploration', 'Deduction', 'Traversal'];
+  locked: Set<string> = new Set();
   model: Character = {
     name: '',
     description: '',
@@ -34,6 +36,7 @@ export class CharacterFormComponent implements OnInit {
     skills: [],
     interactions: []
   };
+  created: Character | null = null;
 
   constructor(private api: ApiService) {}
 
@@ -45,6 +48,39 @@ export class CharacterFormComponent implements OnInit {
     if (!this.model.license) return;
     this.api.getSkills(this.model.license).subscribe(s => this.skills = s);
     this.api.getInteractions(this.model.license).subscribe(i => this.interactions = i);
+    this.setTrainingDefaults();
+  }
+
+  setTrainingDefaults() {
+    this.locked.clear();
+    this.abilityKeys.forEach(k => (this.model.abilities[k] = ''));
+    const rules: any = {
+      Archivist: { strength: 'Observation', weakness: 'Traversal' },
+      Fixer: { strength: 'Deduction', weakness: 'Traversal' },
+      Guardian: { strength: 'Traversal', weakness: 'Deduction' },
+    };
+    const r = rules[this.model.license as keyof typeof rules];
+    if (r) {
+      this.locked.add(r.strength);
+      this.locked.add(r.weakness);
+      this.model.abilities[r.strength] = 'd6';
+      this.model.abilities[r.weakness] = 'd4';
+    }
+  }
+
+  randomizeDiviner() {
+    if (this.model.license !== 'Diviner') return;
+    this.locked.clear();
+    const pool = [...this.abilityKeys];
+    const strength = pool.splice(Math.floor(Math.random() * pool.length), 1)[0];
+    const weakness = pool.splice(Math.floor(Math.random() * pool.length), 1)[0];
+    this.locked.add(strength);
+    this.locked.add(weakness);
+    this.model.abilities[strength] = 'd6';
+    this.model.abilities[weakness] = 'd4';
+    // leave remaining abilities empty so the player must assign them
+    this.model.abilities[pool[0]] = '';
+    this.model.abilities[pool[1]] = '';
   }
 
   toggleSkill(skill: string, checked: boolean) {
@@ -63,9 +99,33 @@ export class CharacterFormComponent implements OnInit {
     }
   }
 
+  isDieDisabled(key: string, die: string): boolean {
+    let d4 = 0,
+      d6 = 0;
+    for (const k of this.abilityKeys) {
+      if (k === key) continue;
+      if (this.model.abilities[k] === 'd4') d4++;
+      if (this.model.abilities[k] === 'd6') d6++;
+    }
+    if (die === 'd4') return d4 >= 2;
+    return d6 >= 2;
+  }
+
   save() {
-    this.api.createCharacter(this.model).subscribe(res => {
-      alert('Character saved with id ' + res.id);
+    for (const key of this.abilityKeys) {
+      if (!this.model.abilities[key]) {
+        alert('Please assign dice to all abilities.');
+        return;
+      }
+    }
+
+    this.api.createCharacter(this.model).subscribe({
+      next: res => {
+        this.created = res as Character;
+      },
+      error: err => {
+        alert('Error: ' + (err.error?.detail || 'unknown'));
+      },
     });
   }
 }

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -11,8 +11,9 @@
   <style>
     body {
       margin: 0;
-      background-color: #f2f2f2;
+      background: linear-gradient(135deg, #e0f7fa, #f3e5f5);
       font-family: Arial, sans-serif;
+      min-height: 100vh;
     }
   </style>
 </body>


### PR DESCRIPTION
## Summary
- clear non-locked ability fields when selecting a license
- randomize Diviner strength/weakness but leave other abilities empty
- enforce one D4 and one D6 among unlocked abilities
- add gradient styling and material-like buttons

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68662dbcc66c8322946f18cbad7e9180