### PR TITLE
Enforce skill limits

### DIFF
--- a/frontend/src/app/character-form.component.html
+++ b/frontend/src/app/character-form.component.html
@@ -41,14 +41,14 @@
   <div>
     <h3>Skills</h3>
     <div *ngFor="let s of skills">
-      <label><input type="checkbox" [value]="s" (change)="toggleSkill(s, $event.target.checked)"> {{s}}</label>
+      <label><input type="checkbox" [checked]="model.skills.includes(s)" [disabled]="isSkillDisabled(s)" [value]="s" (change)="toggleSkill(s, $event.target.checked)"> {{s}}</label>
     </div>
   </div>
 
   <div>
     <h3>Interactions</h3>
     <div *ngFor="let i of interactions">
-      <label><input type="checkbox" [value]="i" (change)="toggleInteraction(i, $event.target.checked)"> {{i}}</label>
+      <label><input type="checkbox" [checked]="model.interactions.includes(i)" [disabled]="isInteractionDisabled(i)" [value]="i" (change)="toggleInteraction(i, $event.target.checked)"> {{i}}</label>
     </div>
   </div>
 

--- a/frontend/src/app/character-form.component.ts
+++ b/frontend/src/app/character-form.component.ts
@@ -90,6 +90,9 @@ export class CharacterFormComponent implements OnInit {
 
   toggleSkill(skill: string, checked: boolean) {
     if (checked) {
+      if (this.model.skills.length >= 4) {
+        return;
+      }
       this.model.skills = [...this.model.skills, skill];
     } else {
       this.model.skills = this.model.skills.filter(x => x !== skill);
@@ -98,6 +101,9 @@ export class CharacterFormComponent implements OnInit {
 
   toggleInteraction(interaction: string, checked: boolean) {
     if (checked) {
+      if (this.model.interactions.length >= 3) {
+        return;
+      }
       this.model.interactions = [...this.model.interactions, interaction];
     } else {
       this.model.interactions = this.model.interactions.filter(x => x !== interaction);
@@ -114,6 +120,14 @@ export class CharacterFormComponent implements OnInit {
     }
     if (die === 'd4') return d4 >= 2;
     return d6 >= 2;
+  }
+
+  isSkillDisabled(skill: string): boolean {
+    return !this.model.skills.includes(skill) && this.model.skills.length >= 4;
+  }
+
+  isInteractionDisabled(interaction: string): boolean {
+    return !this.model.interactions.includes(interaction) && this.model.interactions.length >= 3;
   }
 
   save() {


### PR DESCRIPTION
## Summary
- limit the number of skills and interactions a user can select
- disable extra skill and interaction checkboxes in the UI

## Testing
- `npm install`
- `npm run build`
- `python -m py_compile backend/app/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686657d96d7c8322ad47b99b9078926d