### PR TITLE
Add filtered skill endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,8 +2,10 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
-from typing import List, Dict
+from typing import List, Dict, Optional
 import io
+import json
+from pathlib import Path
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 
@@ -21,38 +23,23 @@ app.add_middleware(
 ABILITIES = ["Observation", "Exploration", "Deduction", "Traversal"]
 LICENSES = ["Archivist", "Diviner", "Fixer", "Guardian"]
 
-# Placeholder skill and interaction data
-SKILLS: Dict[str, List[str]] = {
-    # Using a subset of the official skill list for brevity
-    "Archivist": [
-        "Local Knowledge",
-        "Geography",
-        "Twitcher",
-        "Wanderer",
-        "Behaviourist",
-    ],
-    "Diviner": [
-        "Whispers",
-        "Intentions",
-        "Patterns",
-        "Presence",
-        "Memories",
-    ],
-    "Fixer": [
-        "Relationships",
-        "Resourceful",
-        "People Watcher",
-        "Steady Hands",
-        "Inner Workings",
-    ],
-    "Guardian": [
-        "Wide Ranging",
-        "Awareness",
-        "Sixth Sense",
-        "Quick Thinking",
-        "Keen Eyed",
-    ],
-}
+
+class SkillDetail(BaseModel):
+    name: str
+    license: str
+    ability: str
+    description: str
+    specialisation: Optional[str] = None
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+with open(ROOT_DIR / "skills_with_details.json", "r", encoding="utf-8") as f:
+    ALL_SKILLS: List[SkillDetail] = [SkillDetail(**s) for s in json.load(f)]
+
+# Map licence -> list of SkillDetail
+SKILLS_BY_LICENSE: Dict[str, List[SkillDetail]] = {}
+for s in ALL_SKILLS:
+    SKILLS_BY_LICENSE.setdefault(s.license, []).append(s)
 
 INTERACTIONS: Dict[str, List[str]] = {
     "Archivist": ["Diagnose", "Sketch", "Study", "Take Samples", "Talk"],
@@ -83,9 +70,18 @@ next_id = 1
 def get_licenses():
     return LICENSES
 
+@app.get("/skills", response_model=List[SkillDetail])
+def list_skills(license: str | None = None, ability: str | None = None):
+    skills = ALL_SKILLS
+    if license:
+        skills = [s for s in skills if s.license == license]
+    if ability:
+        skills = [s for s in skills if s.ability == ability]
+    return skills
+
 @app.get("/skills/{license}", response_model=List[str])
 def get_skills(license: str):
-    return SKILLS.get(license, [])
+    return [s.name for s in SKILLS_BY_LICENSE.get(license, [])]
 
 @app.get("/interactions/{license}", response_model=List[str])
 def get_interactions(license: str):
@@ -122,7 +118,7 @@ def create_character(char: Character):
             )
 
     # validate selected skills
-    allowed_skills = SKILLS.get(char.license, [])
+    allowed_skills = [s.name for s in SKILLS_BY_LICENSE.get(char.license, [])]
     if any(s not in allowed_skills for s in char.skills):
         raise HTTPException(status_code=400, detail="Invalid skill for licence")
     if len(char.skills) != 4:

--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 @Injectable()
@@ -12,8 +12,15 @@ export class ApiService {
     return this.http.get<string[]>(`${this.base}/licenses`);
   }
 
-  getSkills(license: string): Observable<string[]> {
-    return this.http.get<string[]>(`${this.base}/skills/${license}`);
+  getSkills(filters: { license?: string; ability?: string } = {}): Observable<any[]> {
+    let params = new HttpParams();
+    if (filters.license) {
+      params = params.set('license', filters.license);
+    }
+    if (filters.ability) {
+      params = params.set('ability', filters.ability);
+    }
+    return this.http.get<any[]>(`${this.base}/skills`, { params });
   }
 
   getInteractions(license: string): Observable<string[]> {

--- a/frontend/src/app/character-form.component.css
+++ b/frontend/src/app/character-form.component.css
@@ -41,3 +41,8 @@ input[type="text"], textarea, select {
 .save:hover {
   background: linear-gradient(45deg, #478ed1, #42a5f5);
 }
+
+.ability {
+  color: #666;
+  font-size: 0.85em;
+}

--- a/frontend/src/app/character-form.component.html
+++ b/frontend/src/app/character-form.component.html
@@ -41,7 +41,15 @@
   <div>
     <h3>Skills</h3>
     <div *ngFor="let s of skills">
-      <label><input type="checkbox" [checked]="model.skills.includes(s)" [disabled]="isSkillDisabled(s)" [value]="s" (change)="toggleSkill(s, $event.target.checked)"> {{s}}</label>
+      <label>
+        <input
+          type="checkbox"
+          [checked]="model.skills.includes(s.name)"
+          [disabled]="isSkillDisabled(s)"
+          (change)="toggleSkill(s, $event.target.checked)"
+        />
+        {{s.name}} <span class="ability">({{s.ability}})</span>
+      </label>
     </div>
   </div>
 

--- a/frontend/src/app/character-form.component.ts
+++ b/frontend/src/app/character-form.component.ts
@@ -11,6 +11,14 @@ interface Character {
   interactions: string[];
 }
 
+interface Skill {
+  name: string;
+  license: string;
+  ability: string;
+  description: string;
+  specialisation?: string | null;
+}
+
 @Component({
     selector: 'character-form',
     templateUrl: './character-form.component.html',
@@ -19,7 +27,7 @@ interface Character {
 })
 export class CharacterFormComponent implements OnInit {
   licenses: string[] = [];
-  skills: string[] = [];
+  skills: Skill[] = [];
   interactions: string[] = [];
   abilityKeys = ['Observation', 'Exploration', 'Deduction', 'Traversal'];
   locked: Set<string> = new Set();
@@ -46,7 +54,7 @@ export class CharacterFormComponent implements OnInit {
 
   onLicenseChange() {
     if (!this.model.license) return;
-    this.api.getSkills(this.model.license).subscribe(s => this.skills = s);
+    this.api.getSkills({ license: this.model.license }).subscribe(s => this.skills = s);
     this.api.getInteractions(this.model.license).subscribe(i => this.interactions = i);
     this.setTrainingDefaults();
   }
@@ -88,14 +96,14 @@ export class CharacterFormComponent implements OnInit {
     this.model.abilities[pool[1]] = '';
   }
 
-  toggleSkill(skill: string, checked: boolean) {
+  toggleSkill(skill: Skill, checked: boolean) {
     if (checked) {
       if (this.model.skills.length >= 4) {
         return;
       }
-      this.model.skills = [...this.model.skills, skill];
+      this.model.skills = [...this.model.skills, skill.name];
     } else {
-      this.model.skills = this.model.skills.filter(x => x !== skill);
+      this.model.skills = this.model.skills.filter(x => x !== skill.name);
     }
   }
 
@@ -122,8 +130,8 @@ export class CharacterFormComponent implements OnInit {
     return d6 >= 2;
   }
 
-  isSkillDisabled(skill: string): boolean {
-    return !this.model.skills.includes(skill) && this.model.skills.length >= 4;
+  isSkillDisabled(skill: Skill): boolean {
+    return !this.model.skills.includes(skill.name) && this.model.skills.length >= 4;
   }
 
   isInteractionDisabled(interaction: string): boolean {


### PR DESCRIPTION
## Summary
- support full skill definitions server-side
- expose `/skills` with optional licence and ability filters
- validate skill names using the new data
- show skill ability in the character form

## Testing
- `python -m py_compile backend/app/main.py`
- `pytest`
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666220ced48322b427ecdf2d54df41