### PR TITLE
Filter starting skills for new characters

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ class SkillDetail(BaseModel):
     license: str
     ability: str
     description: str
+    level: str
     specialisation: Optional[str] = None
 
 
@@ -71,12 +72,14 @@ def get_licenses():
     return LICENSES
 
 @app.get("/skills", response_model=List[SkillDetail])
-def list_skills(license: str | None = None, ability: str | None = None):
+def list_skills(license: str | None = None, ability: str | None = None, level: str | None = None):
     skills = ALL_SKILLS
     if license:
         skills = [s for s in skills if s.license == license]
     if ability:
         skills = [s for s in skills if s.ability == ability]
+    if level:
+        skills = [s for s in skills if s.level == level]
     return skills
 
 @app.get("/skills/{license}", response_model=List[str])
@@ -117,8 +120,12 @@ def create_character(char: Character):
                 detail=f"{char.license} requires {rules['strength']} d6 and {rules['weakness']} d4",
             )
 
-    # validate selected skills
-    allowed_skills = [s.name for s in SKILLS_BY_LICENSE.get(char.license, [])]
+    # validate selected skills (only starting level allowed on creation)
+    allowed_skills = [
+        s.name
+        for s in SKILLS_BY_LICENSE.get(char.license, [])
+        if s.level == "starting"
+    ]
     if any(s not in allowed_skills for s in char.skills):
         raise HTTPException(status_code=400, detail="Invalid skill for licence")
     if len(char.skills) != 4:

--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -12,13 +12,16 @@ export class ApiService {
     return this.http.get<string[]>(`${this.base}/licenses`);
   }
 
-  getSkills(filters: { license?: string; ability?: string } = {}): Observable<any[]> {
+  getSkills(filters: { license?: string; ability?: string; level?: string } = {}): Observable<any[]> {
     let params = new HttpParams();
     if (filters.license) {
       params = params.set('license', filters.license);
     }
     if (filters.ability) {
       params = params.set('ability', filters.ability);
+    }
+    if (filters.level) {
+      params = params.set('level', filters.level);
     }
     return this.http.get<any[]>(`${this.base}/skills`, { params });
   }

--- a/frontend/src/app/character-form.component.ts
+++ b/frontend/src/app/character-form.component.ts
@@ -16,6 +16,7 @@ interface Skill {
   license: string;
   ability: string;
   description: string;
+  level: string;
   specialisation?: string | null;
 }
 
@@ -54,7 +55,7 @@ export class CharacterFormComponent implements OnInit {
 
   onLicenseChange() {
     if (!this.model.license) return;
-    this.api.getSkills({ license: this.model.license }).subscribe(s => this.skills = s);
+    this.api.getSkills({ license: this.model.license, level: 'starting' }).subscribe(s => this.skills = s);
     this.api.getInteractions(this.model.license).subscribe(i => this.interactions = i);
     this.setTrainingDefaults();
   }


### PR DESCRIPTION
## Summary
- include `level` in skill model
- filter skills by level via new API query parameter
- restrict character creation to starting-level skills
- expose level filter in Angular API service and component

## Testing
- `npm --prefix frontend run build --silent`
- `python -m py_compile backend/app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68667161c024832293ae54286b655ccc