### PR TITLE
Add licence skill rules

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,6 +49,17 @@ INTERACTIONS: Dict[str, List[str]] = {
     "Guardian": ["Explore", "Feed", "Play", "Protect", "Provoke"],
 }
 
+# Starting skill distribution rules per licence
+SKILL_RULES: Dict[str, Dict[str, int]] = {
+    "Archivist": {"Observation": 2, "Deduction": 1, "Exploration": 1},
+    "Diviner": {"Deduction": 2, "Observation": 1, "Exploration": 1},
+    "Fixer": {"Deduction": 2, "Exploration": 1, "Observation": 1},
+    "Guardian": {"Traversal": 2, "Exploration": 1, "Observation": 1},
+}
+
+# Map skill name -> detail for quick lookups
+SKILL_MAP: Dict[str, SkillDetail] = {s.name: s for s in ALL_SKILLS}
+
 class AbilityDice(BaseModel):
     Observation: str = Field(default="")
     Exploration: str = Field(default="")
@@ -130,6 +141,22 @@ def create_character(char: Character):
         raise HTTPException(status_code=400, detail="Invalid skill for licence")
     if len(char.skills) != 4:
         raise HTTPException(status_code=400, detail="Choose exactly four starting skills")
+
+    # enforce ability distribution for starting skills
+    ability_counts: Dict[str, int] = {a: 0 for a in ABILITIES}
+    for s in char.skills:
+        detail = SKILL_MAP.get(s)
+        if detail:
+            ability_counts[detail.ability] += 1
+    rule = SKILL_RULES.get(char.license)
+    if rule:
+        for ability, required in rule.items():
+            if ability_counts.get(ability, 0) != required:
+                needed = ", ".join(f"{n} {a}" for a, n in rule.items())
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{char.license} requires {needed} starting skills",
+                )
 
     # validate interactions
     allowed_interactions = INTERACTIONS.get(char.license, [])

--- a/frontend/src/app/character-form.component.css
+++ b/frontend/src/app/character-form.component.css
@@ -46,3 +46,8 @@ input[type="text"], textarea, select {
   color: #666;
   font-size: 0.85em;
 }
+
+.rule {
+  font-style: italic;
+  margin-top: 0.5rem;
+}

--- a/frontend/src/app/character-form.component.html
+++ b/frontend/src/app/character-form.component.html
@@ -13,6 +13,7 @@
         <option *ngFor="let l of licenses" [value]="l">{{l}}</option>
       </select>
     </label>
+    <div class="rule" *ngIf="ruleText">{{ruleText}}</div>
   </div>
 
   <div>

--- a/frontend/src/app/character-form.component.ts
+++ b/frontend/src/app/character-form.component.ts
@@ -31,6 +31,13 @@ export class CharacterFormComponent implements OnInit {
   skills: Skill[] = [];
   interactions: string[] = [];
   abilityKeys = ['Observation', 'Exploration', 'Deduction', 'Traversal'];
+  licenseSkillRules: Record<string, Record<string, number>> = {
+    Archivist: { Observation: 2, Deduction: 1, Exploration: 1 },
+    Diviner: { Deduction: 2, Observation: 1, Exploration: 1 },
+    Fixer: { Deduction: 2, Exploration: 1, Observation: 1 },
+    Guardian: { Traversal: 2, Exploration: 1, Observation: 1 }
+  };
+  ruleText = '';
   locked: Set<string> = new Set();
   model: Character = {
     name: '',
@@ -58,6 +65,13 @@ export class CharacterFormComponent implements OnInit {
     this.api.getSkills({ license: this.model.license, level: 'starting' }).subscribe(s => this.skills = s);
     this.api.getInteractions(this.model.license).subscribe(i => this.interactions = i);
     this.setTrainingDefaults();
+    const rule = this.licenseSkillRules[this.model.license];
+    if (rule) {
+      const parts = Object.entries(rule).map(([a, n]) => `${n} ${a} Skill${n > 1 ? 's' : ''}`);
+      this.ruleText = `Choose ${parts.join(', ')} from the ${this.model.license} Skill Path Starting Skills.`;
+    } else {
+      this.ruleText = '';
+    }
   }
 
   setTrainingDefaults() {
@@ -108,6 +122,17 @@ export class CharacterFormComponent implements OnInit {
     }
   }
 
+  private getAbilityCounts(): Record<string, number> {
+    const counts: Record<string, number> = {};
+    for (const name of this.model.skills) {
+      const s = this.skills.find(sk => sk.name === name);
+      if (s) {
+        counts[s.ability] = (counts[s.ability] || 0) + 1;
+      }
+    }
+    return counts;
+  }
+
   toggleInteraction(interaction: string, checked: boolean) {
     if (checked) {
       if (this.model.interactions.length >= 3) {
@@ -132,7 +157,16 @@ export class CharacterFormComponent implements OnInit {
   }
 
   isSkillDisabled(skill: Skill): boolean {
-    return !this.model.skills.includes(skill.name) && this.model.skills.length >= 4;
+    if (this.model.skills.includes(skill.name)) return false;
+    const rule = this.licenseSkillRules[this.model.license];
+    if (rule) {
+      const counts = this.getAbilityCounts();
+      const allowed = rule[skill.ability] || 0;
+      if ((counts[skill.ability] || 0) >= allowed) {
+        return true;
+      }
+    }
+    return this.model.skills.length >= 4;
   }
 
   isInteractionDisabled(interaction: string): boolean {


### PR DESCRIPTION
## Summary
- enforce starting skill distributions for each licence in backend
- display licence skill rules in the form
- disable skills once ability quotas are met

## Testing
- `python -m py_compile backend/app/main.py`
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667345380c8322baa07bc16aedb3f9