### PR TITLE
Add skill lookup page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@angular/forms": "^19.2.14",
         "@angular/platform-browser": "^19.2.14",
         "@angular/platform-browser-dynamic": "^19.2.14",
+        "@angular/router": "^19.2.14",
         "rxjs": "^7.8.0",
         "tslib": "^2.6.0",
         "zone.js": "^0.15.1"
@@ -738,6 +739,24 @@
         "@angular/compiler": "19.2.14",
         "@angular/core": "19.2.14",
         "@angular/platform-browser": "19.2.14"
+      }
+    },
+    "node_modules/@angular/router": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-19.2.14.tgz",
+      "integrity": "sha512-cBTWY9Jx7YhbmDYDb7Hqz4Q7UNIMlKTkdKToJd2pbhIXyoS+kHVQrySmyca+jgvYMjWnIjsAEa3dpje12D4mFw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "19.2.14",
+        "@angular/core": "19.2.14",
+        "@angular/platform-browser": "19.2.14",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@angular/compiler": "^19.2.14",
     "@angular/core": "^19.2.14",
     "@angular/forms": "^19.2.14",
+    "@angular/router": "^19.2.14",
     "@angular/platform-browser": "^19.2.14",
     "@angular/platform-browser-dynamic": "^19.2.14",
     "rxjs": "^7.8.0",

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { CharacterFormComponent } from './character-form.component';
+import { SkillLookupComponent } from './skill-lookup.component';
+
+const routes: Routes = [
+  { path: '', component: CharacterFormComponent },
+  { path: 'skills', component: SkillLookupComponent }
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule]
+})
+export class AppRoutingModule {}

--- a/frontend/src/app/app.component.css
+++ b/frontend/src/app/app.component.css
@@ -3,3 +3,20 @@ h1 {
   margin: 2rem 0 1rem;
   color: #3f51b5;
 }
+
+nav {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+nav a {
+  text-decoration: none;
+  color: #3f51b5;
+  padding: 0.25rem 0.5rem;
+}
+
+nav a.active {
+  border-bottom: 2px solid #3f51b5;
+}

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,0 +1,6 @@
+<h1>Mappa Mundi Character Builder</h1>
+<nav>
+  <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">Character Builder</a>
+  <a routerLink="/skills" routerLinkActive="active">Skill Lookup</a>
+</nav>
+<router-outlet></router-outlet>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
 
 @Component({
-    selector: 'app-root',
-    template: '<h1>Mappa Mundi Character Builder</h1><character-form></character-form>',
-    styleUrl: './app.component.css',
-    standalone: false
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css'],
+  standalone: false
 })
 export class AppComponent {}

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -5,8 +5,14 @@ import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 
 import { AppComponent } from './app.component';
 import { CharacterFormComponent } from './character-form.component';
+import { SkillLookupComponent } from './skill-lookup.component';
+import { AppRoutingModule } from './app-routing.module';
 import { ApiService } from './api.service';
 
-@NgModule({ declarations: [AppComponent, CharacterFormComponent],
-    bootstrap: [AppComponent], imports: [BrowserModule, FormsModule], providers: [ApiService, provideHttpClient(withInterceptorsFromDi())] })
+@NgModule({
+  declarations: [AppComponent, CharacterFormComponent, SkillLookupComponent],
+  bootstrap: [AppComponent],
+  imports: [BrowserModule, FormsModule, AppRoutingModule],
+  providers: [ApiService, provideHttpClient(withInterceptorsFromDi())]
+})
 export class AppModule {}

--- a/frontend/src/app/skill-lookup.component.css
+++ b/frontend/src/app/skill-lookup.component.css
@@ -1,0 +1,26 @@
+.lookup-card {
+  background: linear-gradient(#ffffff, #fafafa);
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  max-width: 600px;
+  margin: 2rem auto;
+}
+
+.skill-item {
+  border-top: 1px solid #ddd;
+  padding-top: 1rem;
+  margin-top: 1rem;
+}
+
+.skill-item:first-child {
+  border-top: none;
+  padding-top: 0;
+  margin-top: 0;
+}
+
+.meta {
+  color: #666;
+  font-size: 0.85em;
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/app/skill-lookup.component.html
+++ b/frontend/src/app/skill-lookup.component.html
@@ -1,0 +1,8 @@
+<div class="lookup-card">
+  <label>Search: <input [(ngModel)]="search" placeholder="Enter skill name" /></label>
+  <div *ngFor="let s of filteredSkills" class="skill-item">
+    <h4>{{s.name}}</h4>
+    <div class="meta">{{s.license}} - {{s.ability}}</div>
+    <p>{{s.description}}</p>
+  </div>
+</div>

--- a/frontend/src/app/skill-lookup.component.ts
+++ b/frontend/src/app/skill-lookup.component.ts
@@ -1,0 +1,33 @@
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from './api.service';
+
+interface SkillDetail {
+  name: string;
+  license: string;
+  ability: string;
+  description: string;
+  level: string;
+  specialisation?: string | null;
+}
+
+@Component({
+  selector: 'skill-lookup',
+  templateUrl: './skill-lookup.component.html',
+  styleUrls: ['./skill-lookup.component.css'],
+  standalone: false
+})
+export class SkillLookupComponent implements OnInit {
+  skills: SkillDetail[] = [];
+  search = '';
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit() {
+    this.api.getSkills().subscribe(s => (this.skills = s));
+  }
+
+  get filteredSkills(): SkillDetail[] {
+    const term = this.search.toLowerCase();
+    return this.skills.filter(s => s.name.toLowerCase().includes(term));
+  }
+}


### PR DESCRIPTION
## Summary
- add Angular Router and new SkillLookupComponent
- create navigation menu in AppComponent
- wire AppRoutingModule with character builder and skill lookup pages
- include `@angular/router` dependency

## Testing
- `npm install`
- `npx tsc -p tsconfig.app.json`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68667676fcfc832296a0c3822b8991f6