### PR TITLE
Add hover description for skills

### DIFF
--- a/frontend/src/app/character-form.component.css
+++ b/frontend/src/app/character-form.component.css
@@ -16,6 +16,7 @@ h3 {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   max-width: 600px;
   margin: 2rem auto;
+  position: relative;
 }
 
 input[type="text"], textarea, select {
@@ -50,4 +51,31 @@ input[type="text"], textarea, select {
 .rule {
   font-style: italic;
   margin-top: 0.5rem;
+}
+
+.skills-section {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.skill-desc {
+  width: 250px;
+  position: absolute;
+  right: -270px;
+  top: 0;
+  background: #ffffff;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  opacity: 0;
+  transform: translateX(10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  pointer-events: none;
+}
+
+.skill-desc.show {
+  opacity: 1;
+  transform: translateX(0);
 }

--- a/frontend/src/app/character-form.component.html
+++ b/frontend/src/app/character-form.component.html
@@ -39,18 +39,28 @@
     </button>
   </div>
 
-  <div>
-    <h3>Skills</h3>
-    <div *ngFor="let s of skills">
-      <label>
-        <input
-          type="checkbox"
-          [checked]="model.skills.includes(s.name)"
-          [disabled]="isSkillDisabled(s)"
-          (change)="toggleSkill(s, $event.target.checked)"
-        />
-        {{s.name}} <span class="ability">({{s.ability}})</span>
-      </label>
+  <div class="skills-section">
+    <div class="skill-list">
+      <h3>Skills</h3>
+      <div
+        *ngFor="let s of skills"
+        (mouseenter)="hoveredSkill = s"
+        (mouseleave)="hoveredSkill = null"
+      >
+        <label>
+          <input
+            type="checkbox"
+            [checked]="model.skills.includes(s.name)"
+            [disabled]="isSkillDisabled(s)"
+            (change)="toggleSkill(s, $event.target.checked)"
+          />
+          {{ s.name }} <span class="ability">({{ s.ability }})</span>
+        </label>
+      </div>
+    </div>
+    <div class="skill-desc" [class.show]="hoveredSkill">
+      <h4 *ngIf="hoveredSkill">{{ hoveredSkill.name }}</h4>
+      <p *ngIf="hoveredSkill">{{ hoveredSkill.description }}</p>
     </div>
   </div>
 

--- a/frontend/src/app/character-form.component.ts
+++ b/frontend/src/app/character-form.component.ts
@@ -53,6 +53,7 @@ export class CharacterFormComponent implements OnInit {
     interactions: []
   };
   created: Character | null = null;
+  hoveredSkill: Skill | null = null;
 
   constructor(private api: ApiService) {}
 


### PR DESCRIPTION
## Summary
- show character skill descriptions on hover
- position description panel to the right with smooth transition

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68667b28b5c48322b866b576100f9b54