### PR TITLE
Add improved scenarized character builder

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -60,6 +60,34 @@ SKILL_RULES: Dict[str, Dict[str, int]] = {
 # Map skill name -> detail for quick lookups
 SKILL_MAP: Dict[str, SkillDetail] = {s.name: s for s in ALL_SKILLS}
 
+# Load scenario questions used for the guided character creation
+with open(ROOT_DIR / "backend" / "data" / "scenario_questions.json", "r", encoding="utf-8") as f:
+    SCENARIO_QUESTIONS = json.load(f)
+
+# Short licence descriptions presented after scenario creation
+LICENSE_DESCRIPTIONS: Dict[str, str] = {
+    "Archivist": (
+        "Training: Strength in Observation, Weakness in Traversal. "
+        "Starting Skills: Two Observation skills, one Deduction skill, one Exploration skill. "
+        "Interactions: Choose three from Diagnose, Sketch, Study, Take Samples, Talk."
+    ),
+    "Diviner": (
+        "Training: Strength and Weakness determined by Fate. "
+        "Starting Skills: Two Deduction skills, one Observation skill, one Exploration skill. "
+        "Interactions: Choose three from Gift, Read, Sing, Soothe, Touch."
+    ),
+    "Fixer": (
+        "Training: Strength in Deduction, Weakness in Traversal. "
+        "Starting Skills: Two Deduction skills, one Exploration skill, one Observation skill. "
+        "Interactions: Choose three from Bait, Gift, Provoke, Read, Touch."
+    ),
+    "Guardian": (
+        "Training: Strength in Traversal, Weakness in Deduction. "
+        "Starting Skills: Two Traversal skills, one Exploration skill, one Observation skill. "
+        "Interactions: Choose three from Explore, Feed, Play, Protect, Provoke."
+    ),
+}
+
 class AbilityDice(BaseModel):
     Observation: str = Field(default="")
     Exploration: str = Field(default="")
@@ -74,6 +102,12 @@ class Character(BaseModel):
     abilities: AbilityDice
     skills: List[str] = []
     interactions: List[str] = []
+
+
+class ScenarioAnswers(BaseModel):
+    name: str
+    description: str
+    answers: Dict[str, str]
 
 characters: Dict[int, Character] = {}
 next_id = 1
@@ -100,6 +134,101 @@ def get_skills(license: str):
 @app.get("/interactions/{license}", response_model=List[str])
 def get_interactions(license: str):
     return INTERACTIONS.get(license, [])
+
+
+@app.get("/scenario/questions")
+def get_scenario_questions():
+    """Return the list of guided creation questions."""
+    return SCENARIO_QUESTIONS
+
+
+@app.post("/scenario/build")
+def build_from_scenario(data: ScenarioAnswers):
+    """Create a character based on answers to scenario questions."""
+    license_scores: Dict[str, int] = {l: 0 for l in LICENSES}
+    skills: List[str] = []
+    interactions: List[str] = []
+    ability_choice: str | None = None
+    answers = data.answers
+
+    option_lookup: Dict[str, Dict[str, Dict]] = {}
+    for q in SCENARIO_QUESTIONS:
+        option_lookup[q["id"]] = {o["id"]: o for o in q.get("options", [])}
+
+    for qid, oid in answers.items():
+        option = option_lookup.get(qid, {}).get(oid)
+        if not option:
+            continue
+        if "license" in option:
+            license_scores[option["license"]] += 1
+        if "ability" in option:
+            ability_choice = option["ability"]
+        if "skill" in option:
+            if option["skill"] not in skills:
+                skills.append(option["skill"])
+        if "interaction" in option:
+            if option["interaction"] not in interactions:
+                interactions.append(option["interaction"])
+
+    license = max(license_scores.items(), key=lambda x: x[1])[0]
+
+    # determine ability dice
+    abil_map = {a: "" for a in ABILITIES}
+    training = {
+        "Archivist": {"strength": "Observation", "weakness": "Traversal"},
+        "Fixer": {"strength": "Deduction", "weakness": "Traversal"},
+        "Guardian": {"strength": "Traversal", "weakness": "Deduction"},
+    }
+    rules = training.get(license)
+    if license == "Diviner":
+        strength = ability_choice or "Deduction"
+        weakness = next(a for a in ABILITIES if a != strength)
+        abil_map[strength] = "d6"
+        abil_map[weakness] = "d4"
+    else:
+        if rules:
+            abil_map[rules["strength"]] = "d6"
+            abil_map[rules["weakness"]] = "d4"
+        if ability_choice and ability_choice not in (rules["strength"], rules["weakness"]):
+            abil_map[ability_choice] = "d6"
+    # fill remaining
+    for a in ABILITIES:
+        if not abil_map[a]:
+            abil_map[a] = "d4" if list(abil_map.values()).count("d4") < 2 else "d6"
+    abilities = AbilityDice(**abil_map)
+
+    if len(skills) < 4:
+        defaults = [
+            s.name
+            for s in SKILLS_BY_LICENSE.get(license, [])
+            if s.level == "starting"
+        ]
+        for s in defaults:
+            if len(skills) >= 4:
+                break
+            if s not in skills:
+                skills.append(s)
+
+    if len(interactions) < 3:
+        defaults = INTERACTIONS.get(license, [])
+        for i in defaults:
+            if len(interactions) >= 3:
+                break
+            if i not in interactions:
+                interactions.append(i)
+
+    char = Character(
+        name=data.name,
+        description=data.description,
+        license=license,
+        abilities=abilities,
+        skills=skills,
+        interactions=interactions,
+    )
+    created = create_character(char)
+    result = created.model_dump()
+    result["license_description"] = LICENSE_DESCRIPTIONS.get(license, "")
+    return result
 
 @app.post("/characters", response_model=Character)
 def create_character(char: Character):

--- a/backend/data/scenario_questions.json
+++ b/backend/data/scenario_questions.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "q1",
+    "text": "Within the Mappa Mundi halls you are most often found:",
+    "options": [
+      {"id": "arch", "text": "Cataloguing tales of the past", "license": "Archivist"},
+      {"id": "div", "text": "Interpreting omens and symbols", "license": "Diviner"},
+      {"id": "fix", "text": "Repurposing scrap into tools", "license": "Fixer"},
+      {"id": "gua", "text": "Training with the shieldwall", "license": "Guardian"}
+    ]
+  },
+  {
+    "id": "q2",
+    "text": "On the road you most enjoy:",
+    "options": [
+      {"id": "arch", "text": "Gathering local histories", "license": "Archivist"},
+      {"id": "div", "text": "Watching for portents", "license": "Diviner"},
+      {"id": "fix", "text": "Scavenging for useful junk", "license": "Fixer"},
+      {"id": "gua", "text": "Planning defensive routes", "license": "Guardian"}
+    ]
+  },
+  {
+    "id": "q3",
+    "text": "Which task calls to you first when reaching a new settlement?",
+    "options": [
+      {"id": "arch", "text": "Questioning elders for lore", "license": "Archivist"},
+      {"id": "div", "text": "Reading the local winds", "license": "Diviner"},
+      {"id": "fix", "text": "Checking what might be repaired", "license": "Fixer"},
+      {"id": "gua", "text": "Assessing threats to the people", "license": "Guardian"}
+    ]
+  },
+  {
+    "id": "q4",
+    "text": "You are praised for your ability to:",
+    "options": [
+      {"id": "arch", "text": "Recall obscure stories", "license": "Archivist"},
+      {"id": "div", "text": "Foresee danger", "license": "Diviner"},
+      {"id": "fix", "text": "Fix almost anything", "license": "Fixer"},
+      {"id": "gua", "text": "Stand firm under pressure", "license": "Guardian"}
+    ]
+  },
+  {
+    "id": "q5",
+    "text": "When facing the unknown, you rely on:",
+    "options": [
+      {"id": "obs", "text": "Keen observation", "ability": "Observation"},
+      {"id": "exp", "text": "Bold exploration", "ability": "Exploration"},
+      {"id": "ded", "text": "Careful deduction", "ability": "Deduction"},
+      {"id": "tra", "text": "Unyielding traversal", "ability": "Traversal"}
+    ]
+  },
+  {
+    "id": "q6",
+    "text": "Your early lessons focused on:",
+    "options": [
+      {"id": "arch", "text": "Ancient records and local lore", "skill": "Local Knowledge", "license": "Archivist"},
+      {"id": "div", "text": "Whispers of fate", "skill": "Whispers", "license": "Diviner"},
+      {"id": "fix", "text": "Building trust", "skill": "Relationships", "license": "Fixer"},
+      {"id": "gua", "text": "Tracking dangers", "skill": "Wide Ranging", "license": "Guardian"}
+    ]
+  },
+  {
+    "id": "q7",
+    "text": "In quiet moments you study:",
+    "options": [
+      {"id": "arch", "text": "Maps and terrain", "skill": "Geography", "license": "Archivist"},
+      {"id": "div", "text": "Patterns in chance", "skill": "Patterns", "license": "Diviner"},
+      {"id": "fix", "text": "Useful odds and ends", "skill": "Resourceful", "license": "Fixer"},
+      {"id": "gua", "text": "Signs of movement", "skill": "Awareness", "license": "Guardian"}
+    ]
+  },
+  {
+    "id": "q8",
+    "text": "You most often consult with:",
+    "options": [
+      {"id": "arch", "text": "Bird watchers and storytellers", "skill": "Twitcher", "license": "Archivist"},
+      {"id": "div", "text": "Prophets and dreamers", "skill": "Presence", "license": "Diviner"},
+      {"id": "fix", "text": "Traders and engineers", "skill": "People Watcher", "license": "Fixer"},
+      {"id": "gua", "text": "Seasoned scouts", "skill": "Sixth Sense", "license": "Guardian"}
+    ]
+  },
+  {
+    "id": "q9",
+    "text": "When trouble brews you usually:",
+    "options": [
+      {"id": "arch", "text": "Venture along hidden paths", "skill": "Wanderer", "license": "Archivist"},
+      {"id": "div", "text": "Read motives and signs", "skill": "Intentions", "license": "Diviner"},
+      {"id": "fix", "text": "Improve your tools", "skill": "Steady Hands", "license": "Fixer"},
+      {"id": "gua", "text": "React quickly to threats", "skill": "Quick Thinking", "license": "Guardian"}
+    ]
+  },
+  {
+    "id": "q10",
+    "text": "Your go-to approach with others is:",
+    "options": [
+      {"id": "arch", "text": "Diagnose their ailments", "interaction": "Diagnose", "license": "Archivist"},
+      {"id": "div", "text": "Offer small gifts of insight", "interaction": "Gift", "license": "Diviner"},
+      {"id": "fix", "text": "Provoke them to act", "interaction": "Provoke", "license": "Fixer"},
+      {"id": "gua", "text": "Shield them from danger", "interaction": "Protect", "license": "Guardian"}
+    ]
+  },
+  {
+    "id": "q11",
+    "text": "When time allows, you like to:",
+    "options": [
+      {"id": "arch", "text": "Sketch what you see", "interaction": "Sketch", "license": "Archivist"},
+      {"id": "div", "text": "Read fortunes", "interaction": "Read", "license": "Diviner"},
+      {"id": "fix", "text": "Share useful salvage", "interaction": "Gift", "license": "Fixer"},
+      {"id": "gua", "text": "Share a meal", "interaction": "Feed", "license": "Guardian"}
+    ]
+  },
+  {
+    "id": "q12",
+    "text": "Others count on you to:",
+    "options": [
+      {"id": "arch", "text": "Study new findings", "interaction": "Study", "license": "Archivist"},
+      {"id": "div", "text": "Soothe frayed nerves", "interaction": "Soothe", "license": "Diviner"},
+      {"id": "fix", "text": "Repair gear on the fly", "interaction": "Touch", "license": "Fixer"},
+      {"id": "gua", "text": "Keep everyone playful", "interaction": "Play", "license": "Guardian"}
+    ]
+  }
+]

--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -30,6 +30,14 @@ export class ApiService {
     return this.http.get<string[]>(`${this.base}/interactions/${license}`);
   }
 
+  getScenarioQuestions(): Observable<any[]> {
+    return this.http.get<any[]>(`${this.base}/scenario/questions`);
+  }
+
+  buildFromScenario(payload: any): Observable<any> {
+    return this.http.post(`${this.base}/scenario/build`, payload);
+  }
+
   createCharacter(char: any): Observable<any> {
     return this.http.post(`${this.base}/characters`, char);
   }

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { CharacterFormComponent } from './character-form.component';
+import { ScenarioFormComponent } from './scenario-form.component';
 import { SkillLookupComponent } from './skill-lookup.component';
 
 const routes: Routes = [
   { path: '', component: CharacterFormComponent },
+  { path: 'scenario', component: ScenarioFormComponent },
   { path: 'skills', component: SkillLookupComponent }
 ];
 

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,6 +1,7 @@
 <h1>Mappa Mundi Character Builder</h1>
 <nav>
   <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">Character Builder</a>
+  <a routerLink="/scenario" routerLinkActive="active">Scenarized Builder</a>
   <a routerLink="/skills" routerLinkActive="active">Skill Lookup</a>
 </nav>
 <router-outlet></router-outlet>

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -5,12 +5,13 @@ import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http'
 
 import { AppComponent } from './app.component';
 import { CharacterFormComponent } from './character-form.component';
+import { ScenarioFormComponent } from './scenario-form.component';
 import { SkillLookupComponent } from './skill-lookup.component';
 import { AppRoutingModule } from './app-routing.module';
 import { ApiService } from './api.service';
 
 @NgModule({
-  declarations: [AppComponent, CharacterFormComponent, SkillLookupComponent],
+  declarations: [AppComponent, CharacterFormComponent, ScenarioFormComponent, SkillLookupComponent],
   bootstrap: [AppComponent],
   imports: [BrowserModule, FormsModule, AppRoutingModule],
   providers: [ApiService, provideHttpClient(withInterceptorsFromDi())]

--- a/frontend/src/app/scenario-form.component.html
+++ b/frontend/src/app/scenario-form.component.html
@@ -1,0 +1,37 @@
+<div class="form-card">
+  <label>Name: <input [(ngModel)]="name" /></label>
+
+  <div *ngFor="let q of questions">
+    <h3>{{q.text}}</h3>
+    <div *ngFor="let o of q.options">
+      <label>
+        <input type="radio" [name]="q.id" [value]="o.id" [(ngModel)]="answers[q.id]" />
+        {{o.text}}
+      </label>
+    </div>
+  </div>
+
+  <div>
+    <label>Description:</label>
+    <textarea [(ngModel)]="description"></textarea>
+  </div>
+
+  <button class="save" (click)="submit()">Submit</button>
+</div>
+
+<div *ngIf="result" class="result-card">
+  <h2>Saved Character</h2>
+  <p><strong>ID:</strong> {{result.id}}</p>
+  <p><strong>Name:</strong> {{result.name}}</p>
+  <p><strong>Description:</strong> {{result.description}}</p>
+  <p><strong>License:</strong> {{result.license}}</p>
+  <p>{{result.license_description}}</p>
+  <div>
+    <h3>Abilities</h3>
+    <div *ngFor="let key of ['Observation','Exploration','Deduction','Traversal']">
+      {{key}}: {{result.abilities[key]}}
+    </div>
+  </div>
+  <p><strong>Skills:</strong> {{result.skills.join(', ')}}</p>
+  <p><strong>Interactions:</strong> {{result.interactions.join(', ')}}</p>
+</div>

--- a/frontend/src/app/scenario-form.component.ts
+++ b/frontend/src/app/scenario-form.component.ts
@@ -1,0 +1,30 @@
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from './api.service';
+
+@Component({
+  selector: 'scenario-form',
+  templateUrl: './scenario-form.component.html',
+  styleUrls: ['./character-form.component.css'],
+  standalone: false
+})
+export class ScenarioFormComponent implements OnInit {
+  questions: any[] = [];
+  answers: Record<string, string> = {};
+  name = '';
+  description = '';
+  result: any | null = null;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit() {
+    this.api.getScenarioQuestions().subscribe(q => (this.questions = q));
+  }
+
+  submit() {
+    const payload = { name: this.name, description: this.description, answers: this.answers };
+    this.api.buildFromScenario(payload).subscribe({
+      next: res => (this.result = res),
+      error: err => alert('Error: ' + (err.error?.detail || 'unknown'))
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- extend scenario creation questions to cover license, skills and interactions
- return licence description from the scenario builder endpoint
- tweak backend logic for building characters from scenario answers
- show the licence description in the scenario result view

## Testing
- `python -m py_compile backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_686681c5ec0c8322bc14d1a43a778cc6