### PR TITLE
Fix scenario builder template

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -197,13 +197,32 @@ def build_from_scenario(data: ScenarioAnswers):
             abil_map[a] = "d4" if list(abil_map.values()).count("d4") < 2 else "d6"
     abilities = AbilityDice(**abil_map)
 
+    # ensure selected skills are valid starting skills for the licence and
+    # satisfy the required ability distribution
+    allowed = [
+        s for s in SKILLS_BY_LICENSE.get(license, []) if s.level == "starting"
+    ]
+    allowed_names = [s.name for s in allowed]
+    skills = [s for s in skills if s in allowed_names]
+
+    rule = SKILL_RULES.get(license, {})
+    ability_counts: Dict[str, int] = {a: 0 for a in ABILITIES}
+    for s in skills:
+        ability = SKILL_MAP.get(s).ability
+        ability_counts[ability] += 1
+
+    by_ability: Dict[str, List[str]] = {}
+    for s in allowed:
+        by_ability.setdefault(s.ability, []).append(s.name)
+
+    for ability, required in rule.items():
+        choices = [n for n in by_ability.get(ability, []) if n not in skills]
+        while ability_counts.get(ability, 0) < required and choices:
+            skills.append(choices.pop(0))
+            ability_counts[ability] += 1
+
     if len(skills) < 4:
-        defaults = [
-            s.name
-            for s in SKILLS_BY_LICENSE.get(license, [])
-            if s.level == "starting"
-        ]
-        for s in defaults:
+        for s in allowed_names:
             if len(skills) >= 4:
                 break
             if s not in skills:

--- a/frontend/src/app/scenario-form.component.html
+++ b/frontend/src/app/scenario-form.component.html
@@ -21,26 +21,6 @@
     <textarea [(ngModel)]="description"></textarea>
     <button class="save" (click)="submit()">Submit</button>
   </div>
-=======
-<div class="form-card">
-  <label>Name: <input [(ngModel)]="name" /></label>
-
-  <div *ngFor="let q of questions">
-    <h3>{{q.text}}</h3>
-    <div *ngFor="let o of q.options">
-      <label>
-        <input type="radio" [name]="q.id" [value]="o.id" [(ngModel)]="answers[q.id]" />
-        {{o.text}}
-      </label>
-    </div>
-  </div>
-
-  <div>
-    <label>Description:</label>
-    <textarea [(ngModel)]="description"></textarea>
-  </div>
-
-  <button class="save" (click)="submit()">Submit</button>
 </div>
 
 <div *ngIf="result" class="result-card">


### PR DESCRIPTION
## Summary
- clean up merge conflict markers in the scenario form
- enforce ability-based skill selection when building a scenario character

## Testing
- `npm run build` *(fails: ng not found)*
- `python -m py_compile backend/app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_686695b2c6c8832281a7b51a7da5a3d8