### PR TITLE
Fix scenario interactions

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -228,6 +228,10 @@ def build_from_scenario(data: ScenarioAnswers):
             if s not in skills:
                 skills.append(s)
 
+    # keep only interactions valid for the determined licence
+    allowed_interactions = INTERACTIONS.get(license, [])
+    interactions = [i for i in interactions if i in allowed_interactions]
+
     if len(interactions) < 3:
         defaults = INTERACTIONS.get(license, [])
         for i in defaults:


### PR DESCRIPTION
## Summary
- restrict scenario interactions to those allowed by the chosen licence

## Testing
- `python -m py_compile backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6866a5edb6548322b77b4973d09be05a