### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm ci
+        working-directory: frontend
+      - run: npx ng build --base-href /Character-builder/
+        working-directory: frontend
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: frontend/dist/app
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ After creating a character you can download a PDF sheet directly from the interf
 The PDF uses `Character_Sheet.png` as a background template if the file is present.
 The front-end displays the same sheet filled with the character data and provides
 a **Download PDF** button once a character is saved.
+
+## GitHub Pages
+
+This repository includes a workflow that automatically builds the Angular app and deploys it to **GitHub Pages** from the `main` branch. Every push to `main` triggers the build and publishes the contents of `frontend/dist/app` as a static website.
+
+Once the workflow has run, the site will be available at `https://<your-username>.github.io/Character-builder/`.


### PR DESCRIPTION
## Summary
- add GitHub Pages workflow
- document Pages deployment in README

## Testing
- `npm test` *(fails: Missing script)*
- `cd frontend && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686792db9e3c83228ebcf471b5b7c909