### PR TITLE
Add dice level up logic

### DIFF
--- a/frontend/src/app/api.service.ts
+++ b/frontend/src/app/api.service.ts
@@ -18,7 +18,10 @@ export interface Character {
   name: string;
   description: string;
   license: string;
+  strength: string;
+  weakness: string;
   abilities: Record<string, string>;
+  training: Record<string, { successes: number; failures: number }>;
   skills: string[];
   interactions: string[];
 }
@@ -91,6 +94,14 @@ export class ApiService {
 
   private validateAndStoreCharacter(char: Character): Character {
     this.validateCharacter(char);
+    if (!char.training) {
+      char.training = {
+        Observation: { successes: 0, failures: 0 },
+        Exploration: { successes: 0, failures: 0 },
+        Deduction: { successes: 0, failures: 0 },
+        Traversal: { successes: 0, failures: 0 }
+      };
+    }
     char.id = this.nextId++;
     this.characters.push(char);
     return char;
@@ -266,7 +277,16 @@ export class ApiService {
       name: payload.name,
       description: payload.description,
       license,
+      strength: rules ? rules.strength : abilityChoice || 'Deduction',
+      weakness:
+        rules ? rules.weakness : ['Observation', 'Exploration', 'Deduction', 'Traversal'].find(a => a !== (abilityChoice || 'Deduction')) as string,
       abilities,
+      training: {
+        Observation: { successes: 0, failures: 0 },
+        Exploration: { successes: 0, failures: 0 },
+        Deduction: { successes: 0, failures: 0 },
+        Traversal: { successes: 0, failures: 0 }
+      },
       skills,
       interactions
     };

--- a/frontend/src/app/character-form.component.html
+++ b/frontend/src/app/character-form.component.html
@@ -18,7 +18,7 @@
   </div>
 
   <div>
-    <h3>Abilities</h3>
+    <h3>Abilities <button class="level" (click)="levelUp()">Level Up</button></h3>
     <div *ngFor="let key of abilityKeys">
       <label>
         {{ key }}:

--- a/frontend/src/app/character-form.component.ts
+++ b/frontend/src/app/character-form.component.ts
@@ -6,7 +6,10 @@ interface Character {
   name: string;
   description: string;
   license: string;
+  strength: string;
+  weakness: string;
   abilities: Record<string, string>;
+  training: Record<string, { successes: number; failures: number }>;
   skills: string[];
   interactions: string[];
 }
@@ -43,11 +46,19 @@ export class CharacterFormComponent implements OnInit {
     name: '',
     description: '',
     license: '',
+    strength: '',
+    weakness: '',
     abilities: {
       Observation: '',
       Exploration: '',
       Deduction: '',
       Traversal: ''
+    },
+    training: {
+      Observation: { successes: 0, failures: 0 },
+      Exploration: { successes: 0, failures: 0 },
+      Deduction: { successes: 0, failures: 0 },
+      Traversal: { successes: 0, failures: 0 }
     },
     skills: [],
     interactions: []
@@ -103,7 +114,11 @@ export class CharacterFormComponent implements OnInit {
 
   setTrainingDefaults() {
     this.locked.clear();
-    this.abilityKeys.forEach(k => (this.model.abilities[k] = ''));
+    this.abilityKeys.forEach(k => {
+      this.model.abilities[k] = '';
+      this.model.training[k].successes = 0;
+      this.model.training[k].failures = 0;
+    });
     const rules: any = {
       Archivist: { strength: 'Observation', weakness: 'Traversal' },
       Fixer: { strength: 'Deduction', weakness: 'Traversal' },
@@ -114,6 +129,8 @@ export class CharacterFormComponent implements OnInit {
     if (r) {
       this.locked.add(r.strength);
       this.locked.add(r.weakness);
+      this.model.strength = r.strength;
+      this.model.weakness = r.weakness;
       this.model.abilities[r.strength] = 'd6';
       this.model.abilities[r.weakness] = 'd4';
       const rest = this.abilityKeys.filter(k => !this.locked.has(k));
@@ -131,8 +148,14 @@ export class CharacterFormComponent implements OnInit {
     const weakness = pool.splice(Math.floor(Math.random() * pool.length), 1)[0];
     this.locked.add(strength);
     this.locked.add(weakness);
+    this.model.strength = strength;
+    this.model.weakness = weakness;
     this.model.abilities[strength] = 'd6';
     this.model.abilities[weakness] = 'd4';
+    this.abilityKeys.forEach(k => {
+      this.model.training[k].successes = 0;
+      this.model.training[k].failures = 0;
+    });
     // leave remaining abilities empty so the player must assign them
     this.model.abilities[pool[0]] = '';
     this.model.abilities[pool[1]] = '';
@@ -216,6 +239,54 @@ export class CharacterFormComponent implements OnInit {
         alert('Error: ' + (err.error?.detail || 'unknown'));
       }
     });
+  }
+
+  levelUp() {
+    const char: Character = (this.created || this.model) as Character;
+    const ladder = ['d4', 'd6', 'd8', 'd12'];
+    const messages: string[] = [];
+    for (const ability of this.abilityKeys) {
+      const current = char.abilities[ability];
+      const idx = ladder.indexOf(current);
+      if (idx === -1 || idx === ladder.length - 1) {
+        messages.push(`${ability} is already at maximum (${current}).`);
+        continue;
+      }
+      const nextDie = ladder[idx + 1];
+      const faces = parseInt(nextDie.slice(1), 10);
+      const reqS = faces;
+      const reqF = Math.floor(faces / 2);
+      const prog = char.training[ability] || { successes: 0, failures: 0 };
+      const needS = Math.max(reqS - prog.successes, 0);
+      const needF = Math.max(reqF - prog.failures, 0);
+      let allowed = needS === 0 && needF === 0;
+      if (allowed) {
+        if (ability !== char.strength) {
+          const strengthDie = char.abilities[char.strength];
+          if (ladder.indexOf(strengthDie) < idx + 1) allowed = false;
+        }
+        if (ability === char.weakness) {
+          for (const a of this.abilityKeys) {
+            if (a === char.weakness) continue;
+            if (ladder.indexOf(char.abilities[a]) < idx + 1) {
+              allowed = false;
+              break;
+            }
+          }
+        }
+      }
+      if (allowed) {
+        char.abilities[ability] = nextDie;
+        prog.successes -= reqS;
+        prog.failures -= reqF;
+        messages.push(`${ability} upgraded to ${nextDie}!`);
+      } else {
+        messages.push(
+          `${ability}: need ${needS} more successes and ${needF} more failures for ${nextDie}.`
+        );
+      }
+    }
+    alert(messages.join('\n'));
   }
 
 }

--- a/frontend/src/app/character-sheet.component.ts
+++ b/frontend/src/app/character-sheet.component.ts
@@ -5,7 +5,10 @@ export interface Character {
   name: string;
   description: string;
   license: string;
+  strength: string;
+  weakness: string;
   abilities: Record<string, string>;
+  training: Record<string, { successes: number; failures: number }>;
   skills: string[];
   interactions: string[];
 }
@@ -20,12 +23,12 @@ export class CharacterSheetComponent {
   @Input() character!: Character;
 
   strengthAbility(c: Character): string {
-    const entry = Object.entries(c.abilities).find(([_, v]) => v === 'd6');
-    return entry ? entry[0] : '';
+    return c.strength ||
+      (Object.entries(c.abilities).find(([_, v]) => v === 'd6')?.[0] || '');
   }
 
   weaknessAbility(c: Character): string {
-    const entry = Object.entries(c.abilities).find(([_, v]) => v === 'd4');
-    return entry ? entry[0] : '';
+    return c.weakness ||
+      (Object.entries(c.abilities).find(([_, v]) => v === 'd4')?.[0] || '');
   }
 }


### PR DESCRIPTION
## Summary
- add tracking for ability training progress
- include strength and weakness in character data
- implement level-up button with upgrade rules
- display current requirements when leveling up

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e3f6a451c8322844d5afc78a4c6b6