### PR TITLE
Add interactive level up controls

### DIFF
--- a/frontend/src/app/character-form.component.css
+++ b/frontend/src/app/character-form.component.css
@@ -76,3 +76,12 @@ input[type="text"], textarea, select {
   transform: translateX(0);
 }
 
+.level {
+  margin-left: 0.5rem;
+}
+
+button.level-option {
+  margin-left: 0.5rem;
+  padding: 0 0.5rem;
+}
+

--- a/frontend/src/app/character-form.component.html
+++ b/frontend/src/app/character-form.component.html
@@ -30,7 +30,18 @@
         <span *ngIf="locked.has(key)">
           {{ model.abilities[key] === "d6" ? "(Strength)" : "(Weakness)" }}
         </span>
+        <button
+          class="level-option"
+          *ngIf="leveling"
+          (click)="upgradeAbility(key)"
+          [disabled]="!levelInfo[key]?.allowed"
+        >
+          +
+        </button>
       </label>
+      <div *ngIf="leveling">
+        Need {{ levelInfo[key]?.needS }} successes and {{ levelInfo[key]?.needF }} failures
+      </div>
     </div>
     <button *ngIf="model.license === 'Diviner'" (click)="randomizeDiviner()">
       Roll Strength & Weakness

--- a/frontend/src/app/character-form.component.ts
+++ b/frontend/src/app/character-form.component.ts
@@ -66,6 +66,9 @@ export class CharacterFormComponent implements OnInit {
   created: Character | null = null;
   hoveredSkill: Skill | null = null;
 
+  leveling = false;
+  levelInfo: Record<string, { needS: number; needF: number; allowed: boolean; nextDie: string }> = {};
+
 
   constructor(private api: ApiService) {}
 
@@ -241,15 +244,15 @@ export class CharacterFormComponent implements OnInit {
     });
   }
 
-  levelUp() {
+  private computeLevelInfo() {
     const char: Character = (this.created || this.model) as Character;
     const ladder = ['d4', 'd6', 'd8', 'd12'];
-    const messages: string[] = [];
+    this.levelInfo = {};
     for (const ability of this.abilityKeys) {
       const current = char.abilities[ability];
       const idx = ladder.indexOf(current);
       if (idx === -1 || idx === ladder.length - 1) {
-        messages.push(`${ability} is already at maximum (${current}).`);
+        this.levelInfo[ability] = { needS: 0, needF: 0, allowed: false, nextDie: current };
         continue;
       }
       const nextDie = ladder[idx + 1];
@@ -275,18 +278,28 @@ export class CharacterFormComponent implements OnInit {
           }
         }
       }
-      if (allowed) {
-        char.abilities[ability] = nextDie;
-        prog.successes -= reqS;
-        prog.failures -= reqF;
-        messages.push(`${ability} upgraded to ${nextDie}!`);
-      } else {
-        messages.push(
-          `${ability}: need ${needS} more successes and ${needF} more failures for ${nextDie}.`
-        );
-      }
+      this.levelInfo[ability] = { needS, needF, allowed, nextDie };
     }
-    alert(messages.join('\n'));
+  }
+
+  levelUp() {
+    this.leveling = !this.leveling;
+    if (this.leveling) {
+      this.computeLevelInfo();
+    }
+  }
+
+  upgradeAbility(ability: string) {
+    this.computeLevelInfo();
+    const info = this.levelInfo[ability];
+    if (!info || !info.allowed) return;
+    const char: Character = (this.created || this.model) as Character;
+    char.abilities[ability] = info.nextDie;
+    const reqS = parseInt(info.nextDie.slice(1), 10);
+    const reqF = Math.floor(reqS / 2);
+    char.training[ability].successes -= reqS;
+    char.training[ability].failures -= reqF;
+    this.computeLevelInfo();
   }
 
 }


### PR DESCRIPTION
## Summary
- add `leveling` state and compute upgrade requirements
- show plus buttons and requirement text when leveling
- style new level up controls

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e42de9eac83229b1314dc64e1d7eb